### PR TITLE
Fixes #339

### DIFF
--- a/elk/10-syslog.conf
+++ b/elk/10-syslog.conf
@@ -1,6 +1,7 @@
 filter {
     grok {
-      match => { "message" => "%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}" }
+      overwrite => [ "message" ]
+      match => { "message" => "%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:message}" }
       add_field => [ "received_at", "%{@timestamp}" ]
       add_field => [ "received_from", "%{host}" ]
       add_field => [ "program", "%{syslog_program}" ]


### PR DESCRIPTION
This removes syslog data from the message, because timestamp, hostname, program and pid are parsed anyway into their own fields, and postfix-grok-patterns only parses output from postfix (like `^%{POSTFIX_SMTP}$`).
